### PR TITLE
Fix ONE_MB constant definition

### DIFF
--- a/list_large_files.vbs
+++ b/list_large_files.vbs
@@ -1,6 +1,6 @@
 Option Explicit
 
-Const ONE_MB = 1024 * 1024
+Const ONE_MB = 1048576 ' 1024 * 1024
 
 Dim targetPath
 If WScript.Arguments.Count > 0 Then


### PR DESCRIPTION
## Summary
- replace the computed ONE_MB constant with a literal value to avoid the VBScript compilation error

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e29773fcd88332a64c2e1f9ea5df0c